### PR TITLE
fix: replace ruff shorcut `--fix` for `check --fix`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,7 +22,7 @@ jobs:
             poetry config virtualenvs.in-project false
         - uses: chartboost/ruff-action@v1
           with:
-            args: --fix -e --no-cache
+            args: check --fix -e --no-cache
         - name: Set up cache
           uses: actions/cache@v2
           with:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
   rev: v0.7.1
   hooks:
     - id: ruff
-      args: ["--fix"]
+      args: ["check --fix"]
 
 - repo: https://github.com/psf/black
   rev: 24.10.0


### PR DESCRIPTION
### Description

Now we need to use with `ruff` with `check --fix` instead the `--fix`shorcut. The reason is for avoid the error below:

![image](https://github.com/user-attachments/assets/922b1e83-4a86-4c82-b2f2-450f61f6df6b)


* Link to GHA with the error: https://github.com/DeepKernelLabs/airflow-tools/actions/runs/11553317134/job/32154233325
