### PR TITLE
Add missing columns to database table or missing columns in source file

### DIFF
--- a/tests/integration/test_filesystem_to_database.py
+++ b/tests/integration/test_filesystem_to_database.py
@@ -2,7 +2,6 @@ import json
 import numpy as np 
 import pendulum
 import textwrap
-import pytest
 
 from airflow.hooks.base import BaseHook
 
@@ -114,8 +113,8 @@ def test_source_file_with_less_columns_that_database(
     source_sql_hook = BaseHook.get_connection('sqlite_test').get_hook()
     source_sql_hook.run(
         sql=[
-            f'CREATE TABLE test_csv_with_less_columns_that_database (a int, b int, c int, d int, "_DS" date);',
-            f'INSERT INTO test_csv_with_less_columns_that_database VALUES (0, 0, 0, 0, "2024-07-31 00:00:00.000000");'
+            'CREATE TABLE test_csv_with_less_columns_that_database (a int, b int, c int, d int, "_DS" date);',
+            'INSERT INTO test_csv_with_less_columns_that_database VALUES (0, 0, 0, 0, "2024-07-31 00:00:00.000000");'
         ]
     )
 
@@ -166,8 +165,8 @@ def test_source_file_with_more_columns_than_database(
     source_sql_hook = BaseHook.get_connection('sqlite_test').get_hook()
     source_sql_hook.run(
         sql=[
-            f'CREATE TABLE test_csv_with_more_columns_than_database (a int, b int, "_DS" date);',
-            f'INSERT INTO test_csv_with_more_columns_than_database VALUES (0, 0, "2024-07-31 00:00:00.000000");'
+            'CREATE TABLE test_csv_with_more_columns_than_database (a int, b int, "_DS" date);',
+            'INSERT INTO test_csv_with_more_columns_than_database VALUES (0, 0, "2024-07-31 00:00:00.000000");'
         ]
     )
 
@@ -218,8 +217,8 @@ def test_source_file_and_database_with_different_columns(
     source_sql_hook = BaseHook.get_connection('sqlite_test').get_hook()
     source_sql_hook.run(
         sql=[
-            f'CREATE TABLE test_csv_with_more_columns_than_database (a int, d int, _DS date);',
-            f'INSERT INTO test_csv_with_more_columns_than_database VALUES (0, 0, "2024-07-31 00:00:00.000000");'
+            'CREATE TABLE test_csv_with_more_columns_than_database (a int, d int, _DS date);',
+            'INSERT INTO test_csv_with_more_columns_than_database VALUES (0, 0, "2024-07-31 00:00:00.000000");'
         ]
     )
 

--- a/tests/integration/test_filesystem_to_database.py
+++ b/tests/integration/test_filesystem_to_database.py
@@ -244,8 +244,8 @@ def test_source_file_and_database_with_different_columns(
     # 1  1  NaN  2023-10-01 00:00:00.000000  3.0  2.0  # \
     # 2  4  NaN  2023-10-01 00:00:00.000000  6.0  5.0  # |> Added from csv
     # 3  7  NaN  2023-10-01 00:00:00.000000  9.0  8.0  # /
-
+    
     assert set(df.columns) == {'a', 'b', 'c', 'd', '_DS'}
     assert len(df) == 4
-    assert all([np.isnan(i) for i in [df.iloc[0].c, df.iloc[1].d]])
-    assert all([np.isnan(i) for i in [df.iloc[1].d, df.iloc[2].d, df.iloc[3].d]])
+    assert all([np.isnan(i) for i in [df.iloc[0].b, df.iloc[0].c]])  # Original row
+    assert all([np.isnan(i) for i in [df.iloc[1].d, df.iloc[2].d, df.iloc[3].d]])  # Added from source file


### PR DESCRIPTION
### Description 

If the source file has columns not present in the database table, the operator will add the missing columns to the database table and fill the previous rows of those columns with null values.

If the database table has columns not present in the source file, the operator will add the missing columns on source file with a null (`NaN`) value.