### PR TITLE
feat: add FilesystemFileSensor for checking existence of files in a filesystem

### DIFF
--- a/src/airflow_tools/providers/deltalake/sensors/filesystem_file.py
+++ b/src/airflow_tools/providers/deltalake/sensors/filesystem_file.py
@@ -1,0 +1,43 @@
+from airflow.hooks.base import BaseHook
+from airflow.sensors.base import BaseSensorOperator
+from airflow.utils.context import Context
+
+from airflow_tools.filesystems.filesystem_factory import FilesystemFactory
+
+
+class FilesystemFileSensor(BaseSensorOperator):
+    """
+    Check if a file exists in the specified storage.
+
+    This sensor use connection type (`connection.conn_type`) to determine the
+    filesystem type.
+
+    Current supported filesystems:
+
+    - 'aws'
+    - 'azure_databricks_volume'
+    - 'azure_file_share_sp'
+    - 'fs' (LocalFileSystem)
+    - 'google_cloud_platform'
+    - 'wasb' (BlobStorageFilesystem)
+
+    :param filesystem_conn_id: connection id for the filesystem.
+    :param source_path: The path to the file (include bucket name).
+
+    """
+
+    template_fields = ('source_path',)
+
+    def __init__(self, filesystem_conn_id: str, source_path: str, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.source_path = source_path
+        self.filesystem_conn_id = filesystem_conn_id
+
+    def poke(self, context: Context):
+        """
+        Check if the file exists in the specified storage.
+        """
+        conn = BaseHook.get_connection(self.filesystem_conn_id)
+        fs = FilesystemFactory.get_data_lake_filesystem(conn)
+
+        return fs.check_file(self.source_path)

--- a/tests/integration/test_filesystem_file_sensor.py
+++ b/tests/integration/test_filesystem_file_sensor.py
@@ -1,0 +1,56 @@
+import json
+
+
+from airflow_tools.providers.deltalake.sensors.filesystem_file import (
+    FilesystemFileSensor,
+)
+
+
+def test_filesystem_file_sensor(tmp_path, sqlite_database, monkeypatch):
+    """
+    Test FilesystemFileSensor with a local filesystem.
+    """
+    
+    monkeypatch.setenv(
+        'AIRFLOW_CONN_SQLITE_TEST',
+        json.dumps(
+            {
+                'conn_type': 'sqlite',
+                'host': str(sqlite_database),
+            }
+        ),
+    )
+    monkeypatch.setenv(
+        'AIRFLOW_CONN_LOCAL_FS_TEST',
+        json.dumps({'conn_type': 'fs', 'extra': {'path': str(tmp_path)}}),
+    )
+
+    monkeypatch.setenv('AIRFLOW__CORE__EXECUTOR', 'SequentialExecutor')
+
+    # Create folder (tmp dir) and csv file
+    folder_path = tmp_path / 'data_lake/2023/10/01/'
+    folder_path.mkdir(parents=True, exist_ok=True)
+    file_path = folder_path / 'test.csv'
+    file_path.write_text('a,b,c\n1,2,3\n4,5,6\n7,8,9')
+
+    sensor1 = FilesystemFileSensor(
+        task_id='check_file_existence_exist',
+        filesystem_conn_id='local_fs_test',
+        source_path='data_lake/2023/10/01/test.csv',
+        poke_interval=2,
+        timeout=4,
+    )
+
+    sensor2 = FilesystemFileSensor(
+        task_id='test_check_file_existence_no_exist',
+        filesystem_conn_id='local_fs_test',
+        source_path='data_lake/2023/10/01/no-exist-test.csv',
+        poke_interval=2,
+        timeout=4,
+    )
+
+    result1 = sensor1.poke(context={})
+    result2 = sensor2.poke(context={})
+
+    assert result1 == True
+    assert result2 == False


### PR DESCRIPTION
### Description

This sensor allows you to check the existence of a file in a filesystem. It uses the connection type to determine the filesystem type and then uses the appropriate filesystem API to check the file's existence.

The sensor can be configured with the following parameters:

- `filesystem_conn_id`: The connection ID for the filesystem connection.
- `source_path`: path to the file to check.